### PR TITLE
Fix build on 5.1-rc1

### DIFF
--- a/src/wl/sys/wl_cfg80211_hybrid.c
+++ b/src/wl/sys/wl_cfg80211_hybrid.c
@@ -457,7 +457,7 @@ wl_dev_ioctl(struct net_device *dev, u32 cmd, void *arg, u32 len)
 	ifr.ifr_data = (caddr_t)&ioc;
 
 	fs = get_fs();
-	set_fs(get_ds());
+	set_fs(KERNEL_DS);
 #if defined(WL_USE_NETDEV_OPS)
 	err = dev->netdev_ops->ndo_do_ioctl(dev, &ifr, SIOCDEVPRIVATE);
 #else


### PR DESCRIPTION
[5.1 removes the venerable `get_ds()` function](https://github.com/torvalds/linux/commit/736706bee3298208343a76096370e4f6a5c55915), which breaks the build for this module. This trivial PR allows compilation. `KERNEL_DS` has been defined since at least 3.0, so I don't think there are any compatibility concerns there.

Unfortunately, I get panics on 5.1-rc1 with this fix, but I suspect the panics are unrelated to this change. One problem at a time.