### PR TITLE
Skip calls to get_fs()/set_fs() in Linux 5.10

### DIFF
--- a/src/wl/sys/wl_cfg80211_hybrid.c
+++ b/src/wl/sys/wl_cfg80211_hybrid.c
@@ -444,7 +444,9 @@ wl_dev_ioctl(struct net_device *dev, u32 cmd, void *arg, u32 len)
 {
 	struct ifreq ifr;
 	struct wl_ioctl ioc;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0)
 	mm_segment_t fs;
+#endif
 	s32 err = 0;
 
 	BUG_ON(len < sizeof(int));
@@ -456,18 +458,22 @@ wl_dev_ioctl(struct net_device *dev, u32 cmd, void *arg, u32 len)
 	strcpy(ifr.ifr_name, dev->name);
 	ifr.ifr_data = (caddr_t)&ioc;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0)
 	fs = get_fs();
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0)
 	set_fs(KERNEL_DS);
 #else
 	set_fs(get_ds());
 #endif
+#endif
 #if defined(WL_USE_NETDEV_OPS)
 	err = dev->netdev_ops->ndo_do_ioctl(dev, &ifr, SIOCDEVPRIVATE);
 #else
 	err = dev->do_ioctl(dev, &ifr, SIOCDEVPRIVATE);
 #endif
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0)
 	set_fs(fs);
+#endif
 
 	return err;
 }

--- a/src/wl/sys/wl_linux.c
+++ b/src/wl/sys/wl_linux.c
@@ -1657,6 +1657,7 @@ wl_ioctl(struct net_device *dev, struct ifreq *ifr, int cmd)
 		goto done2;
 	}
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0)
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0)
 	if (segment_eq(get_fs(), KERNEL_DS))
 #else
@@ -1665,6 +1666,9 @@ wl_ioctl(struct net_device *dev, struct ifreq *ifr, int cmd)
 		buf = ioc.buf;
 
 	else if (ioc.buf) {
+#else
+	if (ioc.buf) {
+#endif
 		if (!(buf = (void *) MALLOC(wl->osh, MAX(ioc.len, WLC_IOCTL_MAXLEN)))) {
 			bcmerror = BCME_NORESOURCE;
 			goto done2;


### PR DESCRIPTION
Fixes #17